### PR TITLE
Add new patch to `libslave` acknowledging new MySQL 8 Binlog Even Types - Closes #2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ libslave/libslave.a:
 	patch -p0 < patches/libslave_DBUG_ASSERT.patch
 	patch -p0 < patches/libslave_ER_MALFORMED_GTID_SET_ENCODING.patch
 	patch -p0 < patches/libslave_SSL_MODE_DISABLED.patch
+	patch -p0 < patches/libslave_MySQL_8_new_events.patch
 	cd libslave && cmake .
 	cd libslave && make slave_a
 

--- a/patches/libslave_MySQL_8_new_events.patch
+++ b/patches/libslave_MySQL_8_new_events.patch
@@ -1,0 +1,42 @@
+diff --git libslave/slave_log_event.cpp libslave/slave_log_event.cpp
+index 6277100..6a86497 100644
+--- libslave/slave_log_event.cpp
++++ libslave/slave_log_event.cpp
+@@ -364,6 +364,13 @@ bool read_log_event(const char* buf, uint event_len, Basic_event_info& bei, Even
+     case TRANSACTION_CONTEXT_EVENT:
+     case VIEW_CHANGE_EVENT:
+     case XA_PREPARE_LOG_EVENT:
++	// UNSUPPORTED: MySQL 8 events - We only acknowledge the existence of this
++	// events, they remain UNSUPPORTED by this library.
++	// ========================================================================
++	case PARTIAL_UPDATE_ROWS_EVENT:
++	case TRANSACTION_PAYLOAD_EVENT:
++	case HEARTBEAT_LOG_EVENT_V2:
++	// ========================================================================
+         if (event_stat)
+             event_stat->tickOther();
+         return false;
+diff --git libslave/slave_log_event.h libslave/slave_log_event.h
+index 9c66d9f..b5eb714 100644
+--- libslave/slave_log_event.h
++++ libslave/slave_log_event.h
+@@ -87,6 +87,19 @@ enum Log_event_type
+ 
+   XA_PREPARE_LOG_EVENT= 38,
+ 
++  // 8.0 UNSUPPORTED: MySQL 8 events - We only acknowledge the existence of this
++  // events, they remain UNSUPPORTED by this library. Source:
++  //  - https://github.com/mysql/mysql-server/blob/8.0/libbinlogevents/include/binlog_event.h#L347
++  // ========================================================================
++
++  PARTIAL_UPDATE_ROWS_EVENT= 39,
++
++  TRANSACTION_PAYLOAD_EVENT= 40,
++
++  HEARTBEAT_LOG_EVENT_V2= 41,
++
++  // ========================================================================
++
+   ENUM_END_EVENT
+ };
+ 


### PR DESCRIPTION
Closes #2. This patch doesn't add support for the new MySQL 8 event types to `libslave`, this events will remain `UNSUPPORTED` by the library. The patch just acknowledge them, so they are treated as generic events that are not of our interest. 