### PR TITLE
Fix build targets for distro packages

### DIFF
--- a/docker/build/build-centos7/Dockerfile
+++ b/docker/build/build-centos7/Dockerfile
@@ -16,6 +16,7 @@ RUN yum update -y && \
 
 # fpm packaging
 RUN yum install -y ruby rubygems ruby-devel && \
+	gem install --no-ri --no-rdoc dotenv -v '2.8.1' && \
 	gem install --no-ri --no-rdoc ffi -v '1.9.14' && \
 	gem install --no-ri --no-rdoc git -v '1.6' && \
 	gem install --no-ri --no-rdoc fpm -v '1.11.0'

--- a/docker/build/build-centos8/Dockerfile
+++ b/docker/build/build-centos8/Dockerfile
@@ -15,6 +15,9 @@ RUN yum update -y && \
 	wget -q -O /usr/include/mysql/hash.h https://raw.githubusercontent.com/mysql/mysql-server/5.7/include/hash.h
 
 # fpm packaging
+RUN dnf module -y enable ruby:3.0
 RUN yum install -y ruby rubygems ruby-devel && \
-	gem install ffi && \
-	gem install fpm
+	gem install --no-document dotenv -v '2.8.1' && \
+	gem install --no-document rexml -v '3.2.6' && \
+	gem install --no-document ffi -v '1.9.14' && \
+	gem install --no-document fpm -v '1.11.0'

--- a/docker/build/build-debian10/Dockerfile
+++ b/docker/build/build-debian10/Dockerfile
@@ -17,5 +17,6 @@ RUN apt-get -y update && \
 
 # fpm packaging
 RUN apt-get -y install ruby ruby-dev && \
-	gem install ffi && \
-	gem install fpm
+	gem install --no-ri --no-rdoc dotenv -v '2.8.1' && \
+	gem install --no-ri --no-rdoc ffi -v '1.9.14' && \
+	gem install --no-ri --no-rdoc fpm -v '1.11.0'

--- a/docker/build/build-debian11/Dockerfile
+++ b/docker/build/build-debian11/Dockerfile
@@ -17,5 +17,6 @@ RUN apt-get -y update && \
 
 # fpm packaging
 RUN apt-get -y install ruby ruby-dev && \
-	gem install ffi && \
-	gem install fpm
+	gem install --no-document dotenv -v '2.8.1' && \
+	gem install --no-document ffi -v '1.9.14' && \
+	gem install --no-document fpm -v '1.11.0'

--- a/docker/build/build-debian9/Dockerfile
+++ b/docker/build/build-debian9/Dockerfile
@@ -17,5 +17,6 @@ RUN apt-get -y update && \
 
 # fpm packaging
 RUN apt-get -y install ruby ruby-dev && \
-	gem install ffi && \
-	gem install fpm
+	gem install --no-ri --no-rdoc dotenv -v '2.8.1' && \
+	gem install --no-ri --no-rdoc ffi -v '1.9.14' && \
+	gem install --no-ri --no-rdoc fpm -v '1.11.0'

--- a/docker/build/build-ubuntu16/Dockerfile
+++ b/docker/build/build-ubuntu16/Dockerfile
@@ -8,5 +8,6 @@ RUN git config --system --add safe.directory /opt/
 # fpm packaging
 RUN apt-get -y update && \
 	apt-get -y install ruby ruby-dev && \
+	gem install --no-ri --no-rdoc dotenv -v '2.8.1' && \
 	gem install --no-ri --no-rdoc ffi -v '1.9.14' && \
 	gem install --no-ri --no-rdoc fpm -v '1.11.0'

--- a/docker/build/build-ubuntu18/Dockerfile
+++ b/docker/build/build-ubuntu18/Dockerfile
@@ -8,5 +8,6 @@ RUN git config --system --add safe.directory /opt/
 # fpm packaging
 RUN apt-get -y update && \
 	apt-get -y install ruby ruby-dev && \
-	gem install ffi && \
-	gem install fpm
+	gem install --no-ri --no-rdoc dotenv -v '2.8.1' && \
+	gem install --no-ri --no-rdoc ffi -v '1.9.14' && \
+	gem install --no-ri --no-rdoc fpm -v '1.11.0'

--- a/docker/build/build-ubuntu20/Dockerfile
+++ b/docker/build/build-ubuntu20/Dockerfile
@@ -17,5 +17,6 @@ RUN apt-get -y update && \
 
 # fpm packaging
 RUN apt-get -y install ruby ruby-dev && \
-	gem install ffi && \
-	gem install fpm
+	gem install --no-document dotenv -v '2.8.1' && \
+	gem install --no-document ffi -v '1.9.14' && \
+	gem install --no-document fpm -v '1.11.0'


### PR DESCRIPTION
While trying a few patches for this codebase, i noticed none of the build targets for Linux distro packages were working :(

Root cause is that the Ruby On Rails gem dependencies used to generate packages were unversioned, and shifted over time
so that their latest releases are no longer compatible with the Ruby setup for each distro.

This fix pins all RoR gems to known working versions for each distro.