### PR TITLE
Make it possible to connect with caching_sha2_support auth plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ proxysql_binlog_reader: proxysql_binlog_reader.cpp libev/.libs/libev.a libdaemon
 libev/.libs/libev.a:
 	rm -rf libev-4.24 || true
 	tar -zxf libev-4.24.tar.gz
-	cd libev-4.24 && ./configure
+	cd libev && ./configure
 	cd libev && CC=${CC} CXX=${CXX} ${MAKE}
 
 libdaemon/libdaemon/.libs/libdaemon.a:
@@ -39,6 +39,7 @@ libslave/libslave.a:
 	patch -p0 < patches/libslave_ER_MALFORMED_GTID_SET_ENCODING.patch
 	patch -p0 < patches/libslave_SSL_MODE_DISABLED.patch
 	patch -p0 < patches/libslave_MySQL_8_new_events.patch
+	patch -p0 < patches/libslave_GET_SERVER_PUBLIC_KEY.patch
 	cd libslave && cmake .
 	cd libslave && make slave_a
 

--- a/patches/libslave_GET_SERVER_PUBLIC_KEY.patch
+++ b/patches/libslave_GET_SERVER_PUBLIC_KEY.patch
@@ -1,0 +1,24 @@
+--- libslave/nanomysql.h	2025-03-18 22:43:00.849960426 +0200
++++ libslave/nanomysql.h.N	2025-03-18 22:47:05.232376800 +0200
+@@ -100,6 +100,8 @@
+         const unsigned int read_timeout = opts.mysql_read_timeout;
+         const unsigned int write_timeout = opts.mysql_write_timeout;
+         const unsigned int arg_off = SSL_MODE_DISABLED;
++		bool server_get_pubkey = 1;
++		
+         if (connect_timeout > 0)
+         {
+             mysql_options(connection, MYSQL_OPT_CONNECT_TIMEOUT, &connect_timeout);
+@@ -125,7 +127,11 @@
+                      , nullptr
+                      );
+ */
+-    mysql_options(connection, MYSQL_OPT_SSL_MODE, &arg_off);
++        mysql_options(connection, MYSQL_OPT_SSL_MODE, &arg_off);
++		
++        mysql_options(connection, MYSQL_OPT_GET_SERVER_PUBLIC_KEY, &server_get_pubkey);
++	
++	
+     }
+     Connection(const mysql_conn_opts& opts)
+     {


### PR DESCRIPTION
A simple patch that will allow binlog reader to connect to the server using MySQL user which uses `caching_sha2_password` to authenticate