### PR TITLE
Implement update batching.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,10 @@ DEPS :=		./libslave/libslave.a \
 .PHONY: default
 default: proxysql_binlog_reader
 
+SRCS=proxysql_binlog_reader.cpp proxysql_gtid.cpp
 
 proxysql_binlog_reader: libev libdaemon libslave
-	@$(CXX) -o proxysql_binlog_reader proxysql_binlog_reader.cpp -std=c++11 -DGITVERSION=\"$(GIT_VERSION)\" -ggdb $(DEPS) $(IDIRS) $(LDIRS) -rdynamic -lz -ldl -lssl -lcrypto -lpthread -lboost_system -lrt -Wl,-Bstatic -lmysqlclient -Wl,-Bdynamic -ldl -lssl -lcrypto -pthread
+	@$(CXX) -o proxysql_binlog_reader $(SRCS) -std=c++11 -DGITVERSION=\"$(GIT_VERSION)\" -ggdb $(DEPS) $(IDIRS) $(LDIRS) -rdynamic -lz -ldl -lssl -lcrypto -lpthread -lboost_system -lrt -Wl,-Bstatic -lmysqlclient -Wl,-Bdynamic -ldl -lssl -lcrypto -pthread
 # -lperconaserverclient if compiled with percona server
 
 libev/.libs/libev.a:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ on each MySQL server instance run the `proxysql_binlog_reader`, e.g:
 + `-f`: run in foreground - all logging goes to stdout/stderr
 + `-L`: path to log file
 + `-t`: optional update throttling, in milliseconds
++ `-U`: Disable update batching. Necessary for ProxySQL servers older than v3.0.7.
 + `-B`: Optional maximum network buffer size, in bytes
 
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ on each MySQL server instance run the `proxysql_binlog_reader`, e.g:
 + `-f`: run in foreground - all logging goes to stdout/stderr
 + `-L`: path to log file
 + `-t`: optional update throttling, in milliseconds
-+ `-U`: Disable update batching. Necessary for ProxySQL servers older than v3.0.7.
++ `-U`: Disable update batching. Necessary for ProxySQL servers older than v3.0.8.
 + `-B`: Optional maximum network buffer size, in bytes
 
 

--- a/proxysql_binlog_reader.cpp
+++ b/proxysql_binlog_reader.cpp
@@ -23,9 +23,9 @@
 #include <libdaemon/dpid.h>
 #include <libdaemon/dexec.h>
 
-
 #include "Slave.h"
 #include "DefaultExtState.h"
+#include "proxysql_gtid.h"
 
 #define BINLOG_VERSION GITVERSION
 
@@ -57,13 +57,17 @@ void proxy_log_func(const char *fmt, ...) {
 #define proxy_info(fmt, ...)   proxy_log("INFO", fmt, ## __VA_ARGS__);
 #define proxy_error(fmt, ...)  proxy_log("ERROR", fmt, ## __VA_ARGS__);
 
-#define NETBUFLEN                        256
-#define WRITE_CHUNKLEN                   4096
-#define DEFAULT_ERRORLOG                 "/tmp/proxysql_mysqlbinlog.log"
-#define DEFAULT_MYSQL_PORT               3306
-#define DEFAULT_LISTEN_PORT              6020
-#define DEFAULT_MAX_NETBUFLEN_STREAMING  (8 * NETBUFLEN)
-#define DEFAULT_MAX_NETBUFLEN_BATCHED    (8192 * NETBUFLEN)
+#define NETBUFLEN                            256
+#define WRITE_CHUNKLEN                       4096
+#define ERRORLOG_OPEN_FLAGS                  (O_WRONLY | O_APPEND | O_CREAT)
+#define ERRORLOG_STAT_FLAGS                  (S_IWUSR | S_IRGRP | S_IWGRP)
+#define DEFAULT_ERRORLOG                     "/tmp/proxysql_mysqlbinlog.log"
+#define DEFAULT_MYSQL_PORT                   3306
+#define DEFAULT_LISTEN_PORT                  6020
+#define DEFAULT_MAX_NETBUFLEN_STREAMING      (8 * NETBUFLEN)
+#define DEFAULT_MAX_NETBUFLEN_BATCHED        (8192 * NETBUFLEN)
+#define PROXYSQL_UPDATE_BATCHING_MIN_VERSION "3.0.7"
+#define UUID_SIZE_BYTES                      64
 
 struct ev_async async;
 std::vector<struct ev_io *> Clients;
@@ -71,16 +75,14 @@ std::vector<struct ev_io *> Clients;
 pid_t pid;
 time_t laststart;
 pthread_mutex_t pos_mutex;
+
 std::vector<char *> server_uuids;
 std::vector<uint64_t> trx_ids;
-
-std::string gtid_executed_to_string(slave::Position &curpos);
 
 static struct ev_loop *loop;
 
 volatile sig_atomic_t stopflag = 0;
 slave::Slave* sl = NULL;
-
 slave::Position curpos;
 
 int pipefd[2];
@@ -94,6 +96,7 @@ bool foreground = false;
 unsigned int listen_port = DEFAULT_LISTEN_PORT;
 size_t max_netbuflen = 0;
 uint64_t update_freq_ms = 0;
+bool update_batching = true;
 
 static const char * proxysql_binlog_pid_file() {
 	static char fn[512];
@@ -105,14 +108,14 @@ void flush_error_log() {
 	if (foreground==false) {
 		int outfd=0;
 		int errfd=0;
-		outfd=open(errorlog, O_WRONLY | O_APPEND | O_CREAT , S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+		outfd=open(errorlog, ERRORLOG_OPEN_FLAGS, ERRORLOG_STAT_FLAGS);
 		if (outfd>0) {
 			dup2(outfd, STDOUT_FILENO);
 			close(outfd);
 		} else {
 			fprintf(stderr,"Impossible to open file\n");
 		}
-		errfd=open(errorlog, O_WRONLY | O_APPEND | O_CREAT , S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+		errfd=open(errorlog, ERRORLOG_OPEN_FLAGS, ERRORLOG_STAT_FLAGS);
 		if (errfd>0) {
 			dup2(errfd, STDERR_FILENO);
 			close(errfd);
@@ -258,7 +261,39 @@ void daemonize_phase1(char *argv0) {
 	}
 }
 
+std::string position_to_string(slave::Position &curpos) {
+    GTID_Set gtid_set;
 
+    if (!update_batching) {
+        // Generatate a message with individual updates per GTID.
+        std::string out;
+
+        for (auto it=curpos.gtid_executed.begin(); it!=curpos.gtid_executed.end(); ++it) {
+            gtid_set.clear();
+
+            auto uuid = it->first;
+            for (auto itr = it->second.begin(); itr != it->second.end(); ++itr) {
+                gtid_set.add(uuid, itr->first, itr->second);
+            }
+
+            if (!out.empty()) {
+                out += ",";
+            }
+            out += gtid_set.to_string();
+        }
+
+        return out;
+    }
+
+    // GTID string for ranged updates.
+    for (auto it=curpos.gtid_executed.begin(); it!=curpos.gtid_executed.end(); ++it) {
+        auto uuid = it->first;
+        for (auto itr = it->second.begin(); itr != it->second.end(); ++itr) {
+            gtid_set.add(uuid, itr->first, itr->second);
+        }
+	}
+	return gtid_set.to_string();
+}
 
 class Client_Data {
 	public:
@@ -268,8 +303,9 @@ class Client_Data {
 	size_t size;
 	size_t pos;
 	struct ev_io *w;
-	char uuid_server[64];
+	char uuid_server[UUID_SIZE_BYTES];
 	char *ip = NULL;
+
 	Client_Data(struct ev_io *_w) {
 		w = _w;
 		size = NETBUFLEN;
@@ -406,7 +442,7 @@ void io_cb(struct ev_loop *loop, struct ev_io *watcher, int revents) {
 }
 
 void accept_cb(struct ev_loop *loop, struct ev_io *watcher, int revents) {
-	typedef union { 
+    typedef union {
 		struct sockaddr_in in;
 		struct sockaddr_in6 in6;
 	} custom_sockaddr;
@@ -451,7 +487,7 @@ void accept_cb(struct ev_loop *loop, struct ev_io *watcher, int revents) {
 	ev_io_init(client, io_cb, client_sd, EV_READ);
 	ev_io_start(loop, client);
 	pthread_mutex_lock(&pos_mutex);
-	std::string s1 = gtid_executed_to_string(curpos);
+	std::string s1 = position_to_string(curpos);
 	pthread_mutex_unlock(&pos_mutex);
 	custom_data->add_string("ST=" + s1 + "\n");
 	if (custom_data->writeout()) {
@@ -466,18 +502,45 @@ void accept_cb(struct ev_loop *loop, struct ev_io *watcher, int revents) {
 
 void write_clients() {
 	pthread_mutex_lock(&pos_mutex);
+
 	std::vector<struct ev_io *> to_remove;
+	GTID_Set gtid_set;
+
 	for (std::vector<struct ev_io *>::iterator it=Clients.begin(); it!=Clients.end(); ++it) {
 		struct ev_io *w = *it;
 		Client_Data * custom_data = (Client_Data *)w->data;
-		for (std::vector<char *>::size_type i=0; i<server_uuids.size(); i++) {
-			if (custom_data->uuid_server[0]==0 || strncmp(custom_data->uuid_server, server_uuids.at(i), strlen(server_uuids.at(i)))) {
-				strcpy(custom_data->uuid_server,server_uuids.at(i));
-				custom_data->add_string("I1=" + std::string(server_uuids.at(i)) + ":" + std::to_string(trx_ids.at(i)) + "\n");
-			} else {
-				custom_data->add_string("I2=" + std::to_string(trx_ids.at(i)) + "\n");
+
+		if (!update_batching) {
+		    // Generate a I1/I2 message per update per server.
+		    for (std::vector<char *>::size_type i=0; i<server_uuids.size(); i++) {
+				if (custom_data->uuid_server[0]==0 || strncmp(custom_data->uuid_server, server_uuids.at(i), strlen(server_uuids.at(i)))) {
+				    strncpy(custom_data->uuid_server,server_uuids.at(i), UUID_SIZE_BYTES);
+					custom_data->add_string("I1=" + std::string(server_uuids.at(i)) + ":" + std::to_string(trx_ids.at(i)) + "\n");
+				} else {
+				    custom_data->add_string("I2=" + std::to_string(trx_ids.at(i)) + "\n");
+				}
+			}
+	    } else {
+	        // Group updates into a single I1/I2 message per server.
+			gtid_set.clear();
+			for (std::vector<char *>::size_type i=0; i<server_uuids.size(); i++) {
+			    gtid_set.add(server_uuids.at(i), trx_ids.at(i));
+			}
+
+			for (auto mit = gtid_set.map.begin(); mit != gtid_set.map.end(); mit++) {
+			    auto uuid = mit->first;
+				auto gtid_sets = mit->second;
+				for (auto it = gtid_sets.begin(); it != gtid_sets.end(); it++) {
+					if (custom_data->uuid_server[0]==0 || strncmp(custom_data->uuid_server, uuid.c_str(), uuid.size())) {
+	                    strncpy(custom_data->uuid_server, uuid.c_str(), UUID_SIZE_BYTES);
+					    custom_data->add_string("I1=" + uuid + ":" + it->to_string() + "\n");
+					} else {
+				        custom_data->add_string("I2=" + it->to_string() + "\n");
+					}
+				}
 			}
 		}
+
 		if (!custom_data->writeout()) {
 			delete custom_data;
 			to_remove.push_back(w);
@@ -525,7 +588,7 @@ static void sigint_cb (struct ev_loop *loop, ev_signal *w, int revents) {
 	stopflag = 1;
 	sl->close_connection();
 	//std::cout << " Received signal. Stopping at:" << std::endl;
-	std::string s1 = gtid_executed_to_string(curpos);
+	std::string s1 = position_to_string(curpos);
 	//std::cout << s1 << std::endl;
 	proxy_info("Received signal. Stopping at: %s", s1.c_str());
 	ev_break(loop, EVBREAK_ALL);
@@ -570,7 +633,7 @@ class GTID_Server_Dumper {
 		ev_io_init(&ev_accept, accept_cb, sd, EV_READ);
 		ev_io_start(my_loop, &ev_accept);
 		if (update_freq_ms) {
-			proxy_info("Pushing updates every %lums", update_freq_ms);
+			proxy_info("Pushing %s updates every %lums", update_batching ? "batched" : "non-batched", update_freq_ms);
 			ev_timer_init(&timer, timer_cb, update_freq_ms / 1000.0, update_freq_ms / 1000.0);
 			ev_timer_start(my_loop, &timer);
 		} else {
@@ -589,8 +652,6 @@ class GTID_Server_Dumper {
 		close(sd);
 	}
 };
-
-
 
 void bench_xid_callback(unsigned int server_id) {
 	pthread_mutex_lock(&pos_mutex);
@@ -618,30 +679,6 @@ bool isStopping() {
 	return stopflag;
 }
 
-std::string gtid_executed_to_string(slave::Position &curpos) {
-	std::string gtid_set { "" };
-	for (auto it=curpos.gtid_executed.begin(); it!=curpos.gtid_executed.end(); ++it) {
-		std::string s = it->first;
-		s.insert(8,"-");
-		s.insert(13,"-");
-		s.insert(18,"-");
-		s.insert(23,"-");
-		s = s + ":";
-		for (auto itr = it->second.begin(); itr != it->second.end(); ++itr) {
-			std::string s2 = s;
-			s2 = s2 + std::to_string(itr->first);
-			s2 = s2 + "-";
-			s2 = s2 + std::to_string(itr->second);
-			s2 = s2 + ",";
-			gtid_set = gtid_set + s2;
-		}
-	}
-	if (gtid_set.empty() == false) {
-		gtid_set.pop_back();
-	}
-	return gtid_set;
-}
-
 void usage(const char* name) {
 	std::cout << "Usage: " << name << " [args]\n"
 	"\n"
@@ -658,6 +695,7 @@ void usage(const char* name) {
 	"-p: MySQL password.\n"
 	"-l: Listener port (default " << DEFAULT_LISTEN_PORT << ").\n"
 	"-t: Update freqency, in milliseconds. Default is update on every event (0).\n"
+	"-U: Disable update batching. Necessary for ProxySQL server releases older than v" << PROXYSQL_UPDATE_BATCHING_MIN_VERSION << ".\n"
 	"-f: Run in foreground.\n"
 	"-v: Outputs build version.\n"
 	<< std::endl;
@@ -678,7 +716,7 @@ int main(int argc, char** argv) {
 	bool error = false;
 
 	int c;
-	while (-1 != (c = ::getopt(argc, argv, "vfB:t:h:u:p:P:l:L:"))) {
+	while (-1 != (c = ::getopt(argc, argv, "vfUB:t:h:u:p:P:l:L:"))) {
 		switch (c) {
 			case 'B': max_netbuflen = size_t(std::stoi(optarg)); break;
 			case 'f': foreground=true; break;
@@ -692,6 +730,7 @@ int main(int argc, char** argv) {
 			case 'l': listen_port = std::stoi(optarg); break;
 			case 'L': errorstr = optarg; break;
 			case 't': update_freq_ms = std::stoi(optarg); break;
+			case 'U': update_batching = false; break;
 			case 'v':
 				std::cout << "proxysql_binlog_reader version " << BINLOG_VERSION << std::endl;
 				return 1;
@@ -809,7 +848,7 @@ __start_label:
 		slave.enableGtid();
 
 		curpos = slave.getLastBinlogPos();
-		std::string s1 = gtid_executed_to_string(curpos);
+		std::string s1 = position_to_string(curpos);
 
 		// Wait until a valid 'GTID' has been executed for requesting binlog
 		while (s1.empty() && !isStopping()) {
@@ -817,7 +856,7 @@ __start_label:
 			usleep(1000 * 1000);
 
 			curpos = slave.getLastBinlogPos();
-			s1 = gtid_executed_to_string(curpos);
+			s1 = position_to_string(curpos);
 		}
 		proxy_info("Last executed GTID: '%s'", s1.c_str());
 

--- a/proxysql_binlog_reader.cpp
+++ b/proxysql_binlog_reader.cpp
@@ -66,7 +66,7 @@ void proxy_log_func(const char *fmt, ...) {
 #define DEFAULT_LISTEN_PORT                  6020
 #define DEFAULT_MAX_NETBUFLEN_STREAMING      (8 * NETBUFLEN)
 #define DEFAULT_MAX_NETBUFLEN_BATCHED        (8192 * NETBUFLEN)
-#define PROXYSQL_UPDATE_BATCHING_MIN_VERSION "3.0.7"
+#define PROXYSQL_UPDATE_BATCHING_MIN_VERSION "3.0.8"
 #define UUID_SIZE_BYTES                      64
 
 struct ev_async async;

--- a/proxysql_binlog_reader.cpp
+++ b/proxysql_binlog_reader.cpp
@@ -521,7 +521,7 @@ void write_clients() {
 				}
 			}
 	    } else {
-	        // Group updates into a single I1/I2 message per server.
+	        // Group updates into a single I3/I4 message per server.
 			gtid_set.clear();
 			for (std::vector<char *>::size_type i=0; i<server_uuids.size(); i++) {
 			    gtid_set.add(server_uuids.at(i), trx_ids.at(i));
@@ -533,9 +533,9 @@ void write_clients() {
 				for (auto it = gtid_sets.begin(); it != gtid_sets.end(); it++) {
 					if (custom_data->uuid_server[0]==0 || strncmp(custom_data->uuid_server, uuid.c_str(), uuid.size())) {
 	                    strncpy(custom_data->uuid_server, uuid.c_str(), UUID_SIZE_BYTES);
-					    custom_data->add_string("I1=" + uuid + ":" + it->to_string() + "\n");
+					    custom_data->add_string("I3=" + uuid + ":" + it->to_string() + "\n");
 					} else {
-				        custom_data->add_string("I2=" + it->to_string() + "\n");
+				        custom_data->add_string("I4=" + it->to_string() + "\n");
 					}
 				}
 			}

--- a/proxysql_binlog_reader.cpp
+++ b/proxysql_binlog_reader.cpp
@@ -694,7 +694,7 @@ void usage(const char* name) {
 	"-p: MySQL password.\n"
 	"-l: Listener port (default " << DEFAULT_LISTEN_PORT << ").\n"
 	"-t: Update freqency, in milliseconds. Default is update on every event (0).\n"
-	"-U: Disable update batching. Necessary for ProxySQL server releases older than v" << PROXYSQL_UPDATE_BATCHING_MIN_VERSION << ".\n"
+	"-b: Batched updates, 0 or 1 (default 1). Requires ProxySQL v" << PROXYSQL_UPDATE_BATCHING_MIN_VERSION << " or later; set to 0 for older versions.\n"
 	"-f: Run in foreground.\n"
 	"-v: Outputs build version.\n"
 	<< std::endl;
@@ -715,7 +715,7 @@ int main(int argc, char** argv) {
 	bool error = false;
 
 	int c;
-	while (-1 != (c = ::getopt(argc, argv, "vfUB:t:h:u:p:P:l:L:"))) {
+	while (-1 != (c = ::getopt(argc, argv, "vfB:b:t:h:u:p:P:l:L:"))) {
 		switch (c) {
 			case 'B': max_netbuflen = size_t(std::stoi(optarg)); break;
 			case 'f': foreground=true; break;
@@ -729,7 +729,7 @@ int main(int argc, char** argv) {
 			case 'l': listen_port = std::stoi(optarg); break;
 			case 'L': errorstr = optarg; break;
 			case 't': update_freq_ms = std::stoi(optarg); break;
-			case 'U': update_batching = false; break;
+			case 'b': update_batching = std::stoi(optarg) ? true : false; break;
 			case 'v':
 				std::cout << "proxysql_binlog_reader version " << BINLOG_VERSION << std::endl;
 				return 1;

--- a/proxysql_binlog_reader.cpp
+++ b/proxysql_binlog_reader.cpp
@@ -262,35 +262,34 @@ void daemonize_phase1(char *argv0) {
 }
 
 std::string position_to_string(slave::Position &curpos) {
-    GTID_Set gtid_set;
+	GTID_Set gtid_set;
 
-    if (!update_batching) {
-        // Generatate a message with individual updates per GTID.
-        std::string out;
+	if (!update_batching) {
+		// Generatate a message with individual updates per GTID.
+		std::string out;
 
-        for (auto it=curpos.gtid_executed.begin(); it!=curpos.gtid_executed.end(); ++it) {
-            gtid_set.clear();
+		for (auto it=curpos.gtid_executed.begin(); it!=curpos.gtid_executed.end(); ++it) {
+			auto uuid = it->first;
+			for (auto itr = it->second.begin(); itr != it->second.end(); ++itr) {
+				gtid_set.clear();
+				gtid_set.add(uuid, itr->first, itr->second);
 
-            auto uuid = it->first;
-            for (auto itr = it->second.begin(); itr != it->second.end(); ++itr) {
-                gtid_set.add(uuid, itr->first, itr->second);
-            }
+				if (!out.empty()) {
+					out += ",";
+				}
+				out += gtid_set.to_string();
+			}
+		}
 
-            if (!out.empty()) {
-                out += ",";
-            }
-            out += gtid_set.to_string();
-        }
+		return out;
+	}
 
-        return out;
-    }
-
-    // GTID string for ranged updates.
-    for (auto it=curpos.gtid_executed.begin(); it!=curpos.gtid_executed.end(); ++it) {
-        auto uuid = it->first;
-        for (auto itr = it->second.begin(); itr != it->second.end(); ++itr) {
-            gtid_set.add(uuid, itr->first, itr->second);
-        }
+	// GTID string for ranged updates.
+	for (auto it=curpos.gtid_executed.begin(); it!=curpos.gtid_executed.end(); ++it) {
+		auto uuid = it->first;
+		for (auto itr = it->second.begin(); itr != it->second.end(); ++itr) {
+			gtid_set.add(uuid, itr->first, itr->second);
+		}
 	}
 	return gtid_set.to_string();
 }

--- a/proxysql_binlog_reader.cpp
+++ b/proxysql_binlog_reader.cpp
@@ -744,6 +744,12 @@ int main(int argc, char** argv) {
 	} else {
 		errorlog = strdup(errorstr.c_str());
 	}
+
+	// Disable batching, if frequency is 0.
+	if (!update_freq_ms) {
+		update_batching = false;
+	}
+
 	if (!max_netbuflen) {
 		max_netbuflen = size_t(update_freq_ms ? DEFAULT_MAX_NETBUFLEN_STREAMING : DEFAULT_MAX_NETBUFLEN_BATCHED);
 	}

--- a/proxysql_gtid.cpp
+++ b/proxysql_gtid.cpp
@@ -1,0 +1,257 @@
+/* Lifted directly from ProxySQL's codebase: https://github.com/sysown/proxysql/blob/a95acd0a0c3cc747662043c2c03b2b084a5070a3/lib/proxysql_gtid.cpp */
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <sstream>
+
+#include "proxysql_gtid.h"
+
+// Initializes a trxid interval from a range.
+TrxId_Interval::TrxId_Interval(const trxid_t _start, const trxid_t _end) {
+	start = _start;
+	end = _end;
+
+	if (start > end) {
+		std::swap(start, end);
+	}
+}
+
+TrxId_Interval::TrxId_Interval(const trxid_t trxid) : TrxId_Interval(trxid, trxid) {
+}
+
+// Initializes a trxid interval from a C string buffer, in [trxid]{-[trxid]} format.
+TrxId_Interval::TrxId_Interval(const char *s) {
+	start = 0;
+	end = 0;
+
+	if (s == nullptr) {
+		return;
+	}
+
+	trxid_t _start = 0, _end = 0;
+
+	if (sscanf(s, "%ld-%ld", &_start, &_end) == 2) {
+		start = _start;
+		end = _end;
+	} else if (sscanf(s, "%ld", &_start) == 1) {
+		start = _start;
+		end = _start;
+	}
+
+	if (start > end) {
+		std::swap(start, end);
+	}
+}
+
+// Initializes a trxid interval from a string, in [trxid]{-[trxid]} format.
+TrxId_Interval::TrxId_Interval(const std::string& s) : TrxId_Interval(s.c_str()) {
+}
+
+// Checks if another trxid interval is contained in this one,
+const bool TrxId_Interval::contains(const TrxId_Interval& other) {
+	return (other.start >= start && other.end <= end);
+}
+
+// Checks if a given trxid is contained in this interval.
+const bool TrxId_Interval::contains(trxid_t trxid) {
+	return (trxid >= start && trxid <= end);
+}
+
+// Yields a string representation for a trxid interval.
+const std::string TrxId_Interval::to_string(void) {
+	if (start == end) {
+		return std::to_string(start);
+	}
+	return std::to_string(start) + "-" + std::to_string(end);
+}
+
+// Attempts to append a new interval to this interval's end. Returns true if the append succeded, false otherwise.
+const bool TrxId_Interval::append(const TrxId_Interval& other) {
+	if (other.start >= start && other.end >= end && other.start <= (end+1)) {
+		// other overlaps interval at end
+		end = other.end;
+		return true;
+	}
+
+	return false;
+}
+
+// Attempts to merge two trxid intervals. Returns true if the intervals were merged (and potentially modified), false otherwise.
+const bool TrxId_Interval::merge(const TrxId_Interval& other) {
+	if (other.start >= start && other.end <= end) {
+		// other is contained by interval
+		return true;
+	}
+	if (other.start <= start && other.end >= end) {
+		// other contains whole of existing interval
+		start = other.start;
+		end = other.end;
+		return true;
+	}
+	if (other.start <= start && other.end >= (start-1)) {
+		// other overlaps interval at start
+		start = other.start;
+		return true;
+	}
+	if (other.end >= end && other.start <= (end+1)) {
+		// other overlaps interval at end
+		end = other.end;
+		return true;
+	}
+
+	return false;
+}
+
+// Compares two trxid intervals, by strict weak ordering.
+const int TrxId_Interval::cmp(const TrxId_Interval& other) {
+	if (start < other.start) {
+		return -1;
+	}
+	if (start > other.start) {
+		return 1;
+	}
+	if (end < other.end) {
+		return -1;
+	}
+	if (end > other.end) {
+		return 1;
+	}
+	return 0;
+}
+
+const bool TrxId_Interval::operator<(const TrxId_Interval& other) {
+	return cmp(other) == -1;
+}
+
+const bool TrxId_Interval::operator==(const TrxId_Interval& other) {
+	return cmp(other) == 0;
+}
+
+const bool TrxId_Interval::operator!=(const TrxId_Interval& other) {
+	return cmp(other) != 0;
+}
+
+// Initializes a GTID set.
+GTID_Set::GTID_Set() {}
+
+// Creates a copy of this GTID set.
+GTID_Set GTID_Set::copy() {
+	GTID_Set cp;
+	cp.map = map;
+	return cp;
+}
+
+// Clears all GTID set entries.
+void GTID_Set::clear() {
+	map.clear();
+}
+
+// Adds a new trxid interval for a given UUID. Returns true if the set was modified, false otherwise.
+bool GTID_Set::add(const std::string& uuid, const TrxId_Interval& iv) {
+	auto it = map.find(uuid);
+	if (it == map.end()) {
+		// new UUID entry
+		map[uuid].emplace_back(iv);
+		return true;
+	}
+
+	if (!it->second.empty()) {
+		auto& last = it->second.back();
+		if (last.contains(iv)) {
+			return false;
+		}
+		if (last.append(iv)) {
+			return true;
+		}
+	}
+
+	// insert/merge trxid interval...
+	auto pos = it->second.begin();
+	for (; pos != it->second.end(); ++pos) {
+		if (pos->contains(iv)) {
+			// trxid interval is already present, nothing to do
+			return false;
+		}
+		if (pos->merge(iv))
+			break;
+	}
+	if (pos == it->second.end()) {
+		it->second.emplace_back(iv);
+	}
+
+	// ...and merge overlapping trxid ranges, if any
+	it->second.sort();
+	auto a = it->second.begin();
+	while (a != it->second.end()) {
+		auto b = std::next(a);
+		if (b == it->second.end()) {
+			break;
+		}
+		if (a->merge(*b)) {
+				it->second.erase(b);
+				continue;
+		}
+		a++;
+	}
+
+	return true;
+}
+
+// Adds a single trxid for a given UUID. Returns true if the set was modified, false otherwise.
+bool GTID_Set::add(const std::string& uuid, const trxid_t& trxid) {
+	return add(uuid, TrxId_Interval(trxid));
+}
+
+// Adds a new trxid range for a given UUID. Returns true if the set was modified, false otherwise.
+bool GTID_Set::add(const std::string& uuid, const trxid_t& start, const trxid_t& end) {
+	return add(uuid, TrxId_Interval(start, end));
+}
+
+// Adds a new trxid range for a given UUID, as a C string buffer. Returns true if the set was modified, false otherwise.
+bool GTID_Set::add(const std::string& uuid, const char *s) {
+	return add(uuid, TrxId_Interval(s));
+}
+
+// Adds a new trxid range for a given UUID, as a string. Returns true if the set was modified, false otherwise.
+bool GTID_Set::add(const std::string& uuid, const std::string& s) {
+	return add(uuid, TrxId_Interval(s));
+}
+
+// Evaluates whether a trxid is present in any of the intervals for a given UUID.
+const bool GTID_Set::has_gtid(const std::string& uuid, const trxid_t trxid) {
+	auto it = map.find(uuid);
+	if (it == map.end()) {
+		return false;
+	}
+	for (auto itr = it->second.begin(); itr != it->second.end(); ++itr) {
+		if (itr->contains(trxid)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+// Yields a string representation for a GTID set.
+const std::string GTID_Set::to_string(void) {
+	std::stringstream out;
+	bool first_uuid = true;
+	for (auto it=map.begin(); it!=map.end(); ++it) {
+		if (!first_uuid) {
+			out << ",";
+		}
+		std::string uuid = it->first;
+		uuid.insert(8,"-");
+		uuid.insert(13,"-");
+		uuid.insert(18,"-");
+		uuid.insert(23,"-");
+		out << uuid;
+		for (auto itr = it->second.begin(); itr != it->second.end(); ++itr) {
+			out << ":" << itr->to_string();
+		}
+		first_uuid = false;
+	}
+
+	return out.str();
+}

--- a/proxysql_gtid.h
+++ b/proxysql_gtid.h
@@ -1,0 +1,58 @@
+/* Lifted directly from ProxySQL's codebase: https://github.com/sysown/proxysql/blob/a95acd0a0c3cc747662043c2c03b2b084a5070a3/lib/proxysql_gtid.h */
+
+#ifndef PROXYSQL_GTID
+#define PROXYSQL_GTID
+// highly inspired by libslave
+// https://github.com/vozbu/libslave/
+#include <list>
+#include <string>
+#include <unordered_map>
+
+typedef int64_t trxid_t;
+
+// Encapsulates an interval of Transaction IDs.
+class TrxId_Interval {
+	public:
+		trxid_t start;
+		trxid_t end;
+
+	public:
+		explicit TrxId_Interval(const trxid_t _start, const trxid_t _end);
+		explicit TrxId_Interval(const trxid_t trxid);
+		explicit TrxId_Interval(const char* s);
+		explicit TrxId_Interval(const std::string& s);
+
+		const bool contains(const TrxId_Interval& other);
+		const bool contains(trxid_t trxid);
+		const std::string to_string(void);
+		const bool append(const TrxId_Interval& other);
+		const bool merge(const TrxId_Interval& other);
+
+		const int cmp(const TrxId_Interval& other);
+		const bool operator<(const TrxId_Interval& other);
+		const bool operator==(const TrxId_Interval& other);
+		const bool operator!=(const TrxId_Interval& other);
+};
+
+// Encapsulates a map of UUID -> trxid intervals.
+class GTID_Set {
+	public:
+		std::unordered_map<std::string, std::list<TrxId_Interval>> map;
+
+	public:
+		GTID_Set();
+
+		GTID_Set copy();
+		void clear();
+
+		bool add(const std::string& uuid, const TrxId_Interval& iv);
+		bool add(const std::string& uuid, const trxid_t& trxid);
+		bool add(const std::string& uuid, const trxid_t& start, const trxid_t& end);
+		bool add(const std::string& uuid, const char *s);
+		bool add(const std::string& uuid, const std::string &s);
+
+		const bool has_gtid(const std::string& uuid, const trxid_t trxid);
+		const std::string to_string(void);
+};
+
+#endif /* PROXYSQL_GTID */


### PR DESCRIPTION
Follows up recent ProxySQL impovements to support ranged binlog updates; this change **greatly** reduces
network traffic between ProxySQL and the binlog reader process, on setups with high DB load.

For example, before...

```
ST=964f8d2c-5270-11f0-b01b-b0416f104875:1-4626,3d267952-7433-11ef-953e-8ce9ee0da246:1-41446
I1=964f8d2c527011f0b01bb0416f104875:4627
I2=4628
I2=4629
I2=4630
I2=4631
I2=4632
I2=4633
I2=4634
I2=4635
I2=4636
...
```

...and after, batching updates every 100ms with low traffic:

```
ST=3d267952-7433-11ef-953e-8ce9ee0da246:1-41446,964f8d2c-5270-11f0-b01b-b0416f104875:1-4626
I3=964f8d2c527011f0b01bb0416f104875:4627-4628
I4=4629-4632
I4=4633-4636
...
```

See https://github.com/sysown/proxysql_mysqlbinlog/issues/33 for details.