### PR TITLE
Add container image build & test jobs to release workflow

### DIFF
--- a/.github/actions/load-images/action.yml
+++ b/.github/actions/load-images/action.yml
@@ -1,0 +1,19 @@
+name: Load image artifacts
+description: Download all per-distro image tarballs and docker load them.
+runs:
+  using: composite
+  steps:
+    - name: Download all image artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: image-*
+        path: images/
+        merge-multiple: true
+
+    - name: Load images
+      shell: bash
+      run: |
+        for tar in images/*.tar; do
+          echo "loading $tar"; docker load -i "$tar"
+        done
+        docker images | grep proxysql-mysqlbinlog || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,20 +9,20 @@ on:
 permissions:
   contents: write
 
+env:
+  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/proxysql-mysqlbinlog
+
 jobs:
+  # ---------------------------------------------------------------------------
+  # 1. Build distro packages (.deb/.rpm) and attach them to the release.
+  # ---------------------------------------------------------------------------
   package:
     name: package (${{ matrix.distro }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        distro:
-          - centos9
-          - centos10
-          - debian12
-          - debian13
-          - ubuntu22
-          - ubuntu24
+        distro: [centos9, centos10, debian12, debian13, ubuntu22, ubuntu24]
     steps:
       - name: Check out source at release tag
         uses: actions/checkout@v4
@@ -56,3 +56,143 @@ jobs:
             exit 1
           fi
           gh release upload "${{ github.event.release.tag_name }}" "${assets[@]}" --clobber
+
+  # ---------------------------------------------------------------------------
+  # 2. Build container images locally and SAVE them as artifacts.
+  #    Nothing is pushed here; images reach GHCR only after they pass the tests.
+  # ---------------------------------------------------------------------------
+  container-build:
+    name: container-build (${{ matrix.distro }})
+    runs-on: ubuntu-latest
+    needs: package
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [centos9, centos10, debian12, debian13, ubuntu22, ubuntu24]
+    steps:
+      - name: Check out source at release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Download package
+        uses: actions/download-artifact@v4
+        with:
+          name: package-${{ matrix.distro }}
+          path: binaries/
+
+      - name: Build image (load locally, no push)
+        run: make -C docker/images mysqlbinlog-${{ matrix.distro }} IMAGE_PREFIX="${IMAGE_PREFIX}"
+
+      - name: Save image to tarball
+        run: |
+          mkdir -p images
+          docker save "${IMAGE_PREFIX}" -o "images/image-${{ matrix.distro }}.tar"
+          ls -lh images/
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-${{ matrix.distro }}
+          path: images/image-${{ matrix.distro }}.tar
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------------------
+  # 3. Test every built image with the TAP suite.
+  # ---------------------------------------------------------------------------
+  test-images:
+    name: test-images
+    runs-on: ubuntu-latest
+    needs: container-build
+    env:
+      MYSQL_VERSION: "84"
+      RUNNER_IMG: proxysql/proxysql-mysqlbinlog:build-ubuntu24
+    steps:
+      - name: Check out source at release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Load all built images
+        uses: ./.github/actions/load-images
+
+      - name: Build TAP test binaries
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}":/opt/proxysql_mysqlbinlog \
+            -w /opt/proxysql_mysqlbinlog/test/tap \
+            "$RUNNER_IMG" make
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build infra image
+        uses: docker/build-push-action@v6
+        with:
+          context: test/infra
+          file: test/infra/Dockerfile.infra
+          tags: proxysql-binlog-reader-infra:latest
+          load: true
+          cache-from: type=gha,scope=test-infra
+          cache-to: type=gha,mode=max,scope=test-infra
+
+      - name: Test centos9
+        if: ${{ !cancelled() }}
+        run: DISTROS=centos9 bash test/infra/docker-image-test.sh
+
+      - name: Test centos10
+        if: ${{ !cancelled() }}
+        run: DISTROS=centos10 bash test/infra/docker-image-test.sh
+
+      - name: Test debian12
+        if: ${{ !cancelled() }}
+        run: DISTROS=debian12 bash test/infra/docker-image-test.sh
+
+      - name: Test debian13
+        if: ${{ !cancelled() }}
+        run: DISTROS=debian13 bash test/infra/docker-image-test.sh
+
+      - name: Test ubuntu22
+        if: ${{ !cancelled() }}
+        run: DISTROS=ubuntu22 bash test/infra/docker-image-test.sh
+
+      - name: Test ubuntu24
+        if: ${{ !cancelled() }}
+        run: DISTROS=ubuntu24 bash test/infra/docker-image-test.sh
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-test-logs
+          path: test/logs/
+          if-no-files-found: ignore
+
+  # ---------------------------------------------------------------------------
+  # 4. Publish: push the verified images to GHCR.
+  # ---------------------------------------------------------------------------
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    needs: test-images
+    permissions:
+      packages: write
+    steps:
+      - name: Check out source at release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Load all built images
+        uses: ./.github/actions/load-images
+
+      - name: Log into GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push all tags
+        run: docker push --all-tags "${IMAGE_PREFIX}"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@
 ### ```
 
 GIT_VERSION ?= $(shell git describe --tags --long --abbrev=7 2>/dev/null)
+# Fall back to the short commit SHA when no tag is reachable.
+ifeq ($(GIT_VERSION),)
+    GIT_VERSION := $(shell git rev-parse --short=7 HEAD 2>/dev/null)
+endif
 ifeq ($(GIT_VERSION),)
     $(error GIT_VERSION is not set)
 endif

--- a/docker/images/Makefile
+++ b/docker/images/Makefile
@@ -108,7 +108,11 @@ mysqlbinlog-*:
 	ls -1 ./$@/proxysql-mysqlbinlog* | head -1 | xargs -r true || { echo "ERROR: no package found for $@ in ../../binaries/"; ls ../../binaries/; false; }
 	# pre-pull base image to avoid transient Docker Hub timeouts during build
 	BASE_IMG=$$(grep -Po '(?<=^FROM ).*' ./$@/Dockerfile | head -1); \
-	docker pull "$$BASE_IMG"
+	for i in 1 2 3; do \
+		echo "pulling $$BASE_IMG (attempt $$i/3)"; \
+		docker pull "$$BASE_IMG" && break; \
+		[ $$i -lt 3 ] && sleep 5 || { echo "ERROR: failed to pull $$BASE_IMG after 3 attempts"; exit 1; }; \
+	done
 ifndef MULTIARCH
 	# build for local only
 	@echo "building native $@ for 'native' using package '$$(cd ./$@/; ls -1 proxysql-mysqlbinlog*)'"

--- a/docker/images/Makefile
+++ b/docker/images/Makefile
@@ -28,10 +28,20 @@ override NOCACHE := --no-cache
 endif
 
 
-GIT_VERSION := $(shell git describe --long --abbrev=7)
-VERS ?= $(shell git describe --long --abbrev=7 | cut -d- -f1)
-ifeq ($(wildcard ../../binaries/proxysql-mysqlbinlog-${VERS}-*),)
-    $(error VERS=${VERS} ERROR: packages are not built)
+IMAGE_PREFIX ?= proxysql/proxysql-mysqlbinlog
+
+GIT_TAG := $(shell git describe --tags --abbrev=7 2>/dev/null)
+GIT_SHA := $(shell git rev-parse --short=7 HEAD 2>/dev/null)
+
+# 1. Strip leading 'v' from a semver tag (e.g. v0.0.2 -> 0.0.2)
+VERS ?= $(shell echo "$(GIT_TAG)" | grep -Po '(?<=^v|^)[\d\.]+')
+# 2. No semver? Use the tag/describe output as-is (lightweight or non-semver tags)
+ifeq ($(VERS),)
+  VERS = $(GIT_TAG)
+endif
+# 3. No tags at all? Fall back to short commit SHA
+ifeq ($(VERS),)
+  VERS = $(GIT_SHA)
 endif
 
 
@@ -41,7 +51,7 @@ default: mysqlbinlog
 
 .PHONY: cleanimg
 cleanimg:
-	docker images -a | grep 'proxysql/proxysql-mysqlbinlog' | grep -v 'build-' | awk '{print $$3}' | sort | uniq | xargs -r docker rmi -f
+	docker images -a | grep '$(IMAGE_PREFIX)' | grep -v 'build-' | awk '{print $$3}' | sort | uniq | xargs -r docker rmi -f
 
 .PHONY: cleanbuild
 cleanbuild:
@@ -85,15 +95,20 @@ PLTFRMS := linux/amd64
 .PHONY: mysqlbinlog-*
 mysqlbinlog-*: DIST=$(patsubst mysqlbinlog-%,%,$@)
 mysqlbinlog-*: DISTN=$(shell echo ${DIST} | grep -Po '[a-z]+')
-mysqlbinlog-*: TAGV=$(if $(findstring ${DIST},$(DFLTDST)),-t proxysql/proxysql-mysqlbinlog:${VERS},)
-mysqlbinlog-*: TAGL=$(if $(findstring ${DIST},$(DFLTDST)),-t proxysql/proxysql-mysqlbinlog:latest,)
-mysqlbinlog-*: TAGD=-t proxysql/proxysql-mysqlbinlog:${DIST}
-mysqlbinlog-*: TAGVD=-t proxysql/proxysql-mysqlbinlog:${VERS}-${DIST}
-mysqlbinlog-*: TAGDN=$(if $(findstring ${DIST},$(LTSTDST)),-t proxysql/proxysql-mysqlbinlog:${DISTN},)
-mysqlbinlog-*: TAGVDN=$(if $(findstring ${DIST},$(LTSTDST)),-t proxysql/proxysql-mysqlbinlog:${VERS}-${DISTN},)
+mysqlbinlog-*: TAGV=$(if $(findstring ${DIST},$(DFLTDST)),-t $(IMAGE_PREFIX):${VERS},)
+mysqlbinlog-*: TAGL=$(if $(findstring ${DIST},$(DFLTDST)),-t $(IMAGE_PREFIX):latest,)
+mysqlbinlog-*: TAGD=-t $(IMAGE_PREFIX):${DIST}
+mysqlbinlog-*: TAGVD=-t $(IMAGE_PREFIX):${VERS}-${DIST}
+mysqlbinlog-*: TAGDN=$(if $(findstring ${DIST},$(LTSTDST)),-t $(IMAGE_PREFIX):${DISTN},)
+mysqlbinlog-*: TAGVDN=$(if $(findstring ${DIST},$(LTSTDST)),-t $(IMAGE_PREFIX):${VERS}-${DISTN},)
 mysqlbinlog-*:
 	rm -f ./$@/proxysql-mysqlbinlog*
-	cp ../../binaries/proxysql-mysqlbinlog*${VERS}*$(DIST)* ./$@/
+	cp ../../binaries/proxysql-mysqlbinlog_*$(DIST)* ./$@/ 2>/dev/null; \
+	cp ../../binaries/proxysql-mysqlbinlog-*$(DIST)* ./$@/ 2>/dev/null; \
+	ls -1 ./$@/proxysql-mysqlbinlog* | head -1 | xargs -r true || { echo "ERROR: no package found for $@ in ../../binaries/"; ls ../../binaries/; false; }
+	# pre-pull base image to avoid transient Docker Hub timeouts during build
+	BASE_IMG=$$(grep -Po '(?<=^FROM ).*' ./$@/Dockerfile | head -1); \
+	docker pull "$$BASE_IMG"
 ifndef MULTIARCH
 	# build for local only
 	@echo "building native $@ for 'native' using package '$$(cd ./$@/; ls -1 proxysql-mysqlbinlog*)'"
@@ -110,4 +125,4 @@ endif
 
 .PHONY: imglist
 imglist:
-	docker images | grep 'proxysql/proxysql-mysqlbinlog' | grep -v 'build-' || true
+	docker images | grep '$(IMAGE_PREFIX)' | grep -v 'build-' || true

--- a/docker/images/mysqlbinlog-centos10/Dockerfile
+++ b/docker/images/mysqlbinlog-centos10/Dockerfile
@@ -25,4 +25,4 @@ RUN yum clean all && \
 	rm -rf /var/cache/yum && \
 	rm -f *.rpm
 
-CMD ["sh", "-c", "proxysql_binlog_reader -h \"${MYSQL_HOST:-127.0.0.1}\" -u \"${MYSQL_USER:=root}\" -p \"${MYSQL_PASSWORD:-root}\" -P \"${MYSQL_PORT:-3306}\" -l \"${LISTEN_PORT:-6020}\" -t \"${UPDATE_FREQ_MS:-0}\" -f"]
+CMD ["sh", "-c", "proxysql_binlog_reader -h \"${MYSQL_HOST:-127.0.0.1}\" -u \"${MYSQL_USER:=root}\" -p \"${MYSQL_PASSWORD:-root}\" -P \"${MYSQL_PORT:-3306}\" -l \"${LISTEN_PORT:-6020}\" -t \"${UPDATE_FREQ_MS:-0}\" -b \"${BATCHING:-1}\" -f"]

--- a/docker/images/mysqlbinlog-centos9/Dockerfile
+++ b/docker/images/mysqlbinlog-centos9/Dockerfile
@@ -25,4 +25,4 @@ RUN yum clean all && \
 	rm -rf /var/cache/yum && \
 	rm -f *.rpm
 
-CMD ["sh", "-c", "proxysql_binlog_reader -h \"${MYSQL_HOST:-127.0.0.1}\" -u \"${MYSQL_USER:=root}\" -p \"${MYSQL_PASSWORD:-root}\" -P \"${MYSQL_PORT:-3306}\" -l \"${LISTEN_PORT:-6020}\" -t \"${UPDATE_FREQ_MS:-0}\" -f"]
+CMD ["sh", "-c", "proxysql_binlog_reader -h \"${MYSQL_HOST:-127.0.0.1}\" -u \"${MYSQL_USER:=root}\" -p \"${MYSQL_PASSWORD:-root}\" -P \"${MYSQL_PORT:-3306}\" -l \"${LISTEN_PORT:-6020}\" -t \"${UPDATE_FREQ_MS:-0}\" -b \"${BATCHING:-1}\" -f"]

--- a/docker/images/mysqlbinlog-debian12/Dockerfile
+++ b/docker/images/mysqlbinlog-debian12/Dockerfile
@@ -12,4 +12,4 @@ RUN apt clean && \
 	rm -rf /var/lib/apt/lists/* && \
 	rm -f *.deb
 
-CMD ["sh", "-c", "proxysql_binlog_reader -h \"${MYSQL_HOST:-127.0.0.1}\" -u \"${MYSQL_USER:=root}\" -p \"${MYSQL_PASSWORD:-root}\" -P \"${MYSQL_PORT:-3306}\" -l \"${LISTEN_PORT:-6020}\" -t \"${UPDATE_FREQ_MS:-0}\" -f"]
+CMD ["sh", "-c", "proxysql_binlog_reader -h \"${MYSQL_HOST:-127.0.0.1}\" -u \"${MYSQL_USER:=root}\" -p \"${MYSQL_PASSWORD:-root}\" -P \"${MYSQL_PORT:-3306}\" -l \"${LISTEN_PORT:-6020}\" -t \"${UPDATE_FREQ_MS:-0}\" -b \"${BATCHING:-1}\" -f"]

--- a/docker/images/mysqlbinlog-debian13/Dockerfile
+++ b/docker/images/mysqlbinlog-debian13/Dockerfile
@@ -12,4 +12,4 @@ RUN apt clean && \
 	rm -rf /var/lib/apt/lists/* && \
 	rm -f *.deb
 
-CMD ["sh", "-c", "proxysql_binlog_reader -h \"${MYSQL_HOST:-127.0.0.1}\" -u \"${MYSQL_USER:=root}\" -p \"${MYSQL_PASSWORD:-root}\" -P \"${MYSQL_PORT:-3306}\" -l \"${LISTEN_PORT:-6020}\" -t \"${UPDATE_FREQ_MS:-0}\" -f"]
+CMD ["sh", "-c", "proxysql_binlog_reader -h \"${MYSQL_HOST:-127.0.0.1}\" -u \"${MYSQL_USER:=root}\" -p \"${MYSQL_PASSWORD:-root}\" -P \"${MYSQL_PORT:-3306}\" -l \"${LISTEN_PORT:-6020}\" -t \"${UPDATE_FREQ_MS:-0}\" -b \"${BATCHING:-1}\" -f"]

--- a/docker/images/mysqlbinlog-ubuntu22/Dockerfile
+++ b/docker/images/mysqlbinlog-ubuntu22/Dockerfile
@@ -12,4 +12,4 @@ RUN apt clean && \
 	rm -rf /var/lib/apt/lists/* && \
 	rm -f *.deb
 
-CMD ["sh", "-c", "proxysql_binlog_reader -h \"${MYSQL_HOST:-127.0.0.1}\" -u \"${MYSQL_USER:=root}\" -p \"${MYSQL_PASSWORD:-root}\" -P \"${MYSQL_PORT:-3306}\" -l \"${LISTEN_PORT:-6020}\" -t \"${UPDATE_FREQ_MS:-0}\" -f"]
+CMD ["sh", "-c", "proxysql_binlog_reader -h \"${MYSQL_HOST:-127.0.0.1}\" -u \"${MYSQL_USER:=root}\" -p \"${MYSQL_PASSWORD:-root}\" -P \"${MYSQL_PORT:-3306}\" -l \"${LISTEN_PORT:-6020}\" -t \"${UPDATE_FREQ_MS:-0}\" -b \"${BATCHING:-1}\" -f"]

--- a/docker/images/mysqlbinlog-ubuntu24/Dockerfile
+++ b/docker/images/mysqlbinlog-ubuntu24/Dockerfile
@@ -12,4 +12,4 @@ RUN apt clean && \
 	rm -rf /var/lib/apt/lists/* && \
 	rm -f *.deb
 
-CMD ["sh", "-c", "proxysql_binlog_reader -h \"${MYSQL_HOST:-127.0.0.1}\" -u \"${MYSQL_USER:=root}\" -p \"${MYSQL_PASSWORD:-root}\" -P \"${MYSQL_PORT:-3306}\" -l \"${LISTEN_PORT:-6020}\" -t \"${UPDATE_FREQ_MS:-0}\" -f"]
+CMD ["sh", "-c", "proxysql_binlog_reader -h \"${MYSQL_HOST:-127.0.0.1}\" -u \"${MYSQL_USER:=root}\" -p \"${MYSQL_PASSWORD:-root}\" -P \"${MYSQL_PORT:-3306}\" -l \"${LISTEN_PORT:-6020}\" -t \"${UPDATE_FREQ_MS:-0}\" -b \"${BATCHING:-1}\" -f"]

--- a/test/infra/docker-image-test.sh
+++ b/test/infra/docker-image-test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Run the TAP suite against each built container image in CONNECT mode.
+#
+# For every distro the script stands up a FRESH MySQL (so no GTID state
+# leaks between distros), runs the product image as an external reader in
+# two groups, and points the test binaries at it:
+#
+#   batching group (-b 1 -t 300) -> the batched tests
+#   normal   group (-b 0 -t 0)   -> the remaining tests
+#
+# Inputs (env, with defaults):
+#   IMAGE_PREFIX   image repo to test          (proxysql/proxysql-mysqlbinlog)
+#   DISTROS        space-separated distro tags  (all six)
+#   MYSQL_VERSION  dbdeployer version token     (84); MYSQL_PORT is derived
+#   RUNNER_IMG     image carrying the libs to run the *-t binaries
+#
+# Exit status is non-zero if any test failed.
+
+set -u
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+REPO=$(cd "$HERE/../.." && pwd)
+INFRA_DIR="$HERE"
+
+IMAGE_PREFIX=${IMAGE_PREFIX:-proxysql/proxysql-mysqlbinlog}
+DISTROS=${DISTROS:-"centos9 centos10 debian12 debian13 ubuntu22 ubuntu24"}
+MYSQL_VERSION=${MYSQL_VERSION:-84}
+RUNNER_IMG=${RUNNER_IMG:-proxysql/proxysql-mysqlbinlog:build-ubuntu24}
+# Infra image (built by test/infra/docker-compose.yml); also provides the
+# mysql client used below.
+INFRA_IMG=${INFRA_IMG:-proxysql-binlog-reader-infra:latest}
+
+INFRA_CONTAINER=binlog-reader-infra
+
+# Version -> MySQL port table (mirrors test/tap/run.sh).
+port_for() {
+  case "$1" in
+    57) echo 3357 ;;
+    80) echo 3380 ;;
+    84) echo 3384 ;;
+    90) echo 3390 ;;
+    94) echo 3394 ;;
+    *)  echo "unknown MYSQL_VERSION token: $1" >&2; return 1 ;;
+  esac
+}
+MYSQL_PORT=$(port_for "$MYSQL_VERSION") || exit 1
+
+NORMAL_TESTS="test_basic_startup-t test_basic_updates-t test_connect_disconnect-t \
+              test_consecutive_writes-t test_multi_client-t test_sparse_intervals-t"
+BATCH_TESTS="test_batched_updates-t"
+
+NET=""
+rc=0
+
+# Run one *-t binary in connect mode against the reader at IP $1.
+run_test() { # $1=reader_ip  $2=test  $3=label
+  local reader_ip=$1 test=$2 label=$3
+  echo "::group::[$label] $test"
+  if docker run --rm --network "$NET" \
+       -v "$REPO":/opt/proxysql_mysqlbinlog -w /opt/proxysql_mysqlbinlog \
+       -e MYSQL_HOST=mysql -e MYSQL_PORT="$MYSQL_PORT" -e MYSQL_USER=root \
+       -e MYSQL_PASSWORD=root -e MYSQL_VERSION="$MYSQL_VERSION" \
+       -e BINLOG_READER_BIN= -e BINLOG_READER_HOST="$reader_ip" -e BINLOG_READER_PORT=6020 \
+       "$RUNNER_IMG" ./test/tap/tests/"$test"; then
+    echo "RESULT $label/$test: PASS"
+  else
+    echo "RESULT $label/$test: FAIL"; rc=1
+  fi
+  echo "::endgroup::"
+}
+
+# Start the product image as a reader; echo its container IP on the infra net.
+# The client connects by IPv4 only (inet_pton, no DNS), hence the IP.
+start_reader() { # $1=image  $2=batching  $3=freq_ms
+  local image=$1 batching=$2 freq_ms=$3
+  docker rm -f reader >/dev/null 2>&1 || true
+  docker run -d --name reader --network "$NET" \
+    -e MYSQL_HOST=mysql -e MYSQL_PORT="$MYSQL_PORT" -e MYSQL_USER=root \
+    -e MYSQL_PASSWORD=root -e BATCHING="$batching" -e UPDATE_FREQ_MS="$freq_ms" -e LISTEN_PORT=6020 \
+    "$image" >/dev/null
+  # give the reader time to connect and open its listen port
+  sleep 4
+  # Surface why the reader died (e.g. auth failures) — to stderr so it does
+  # not pollute the IP captured by the caller.
+  if [ "$(docker inspect -f '{{.State.Status}}' reader 2>/dev/null)" != running ]; then
+    echo "reader container is not running; logs:" >&2
+    docker logs reader >&2 2>&1 || true
+  fi
+  docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' reader
+}
+
+# Run one reader group: start the reader, run its tests, then drop it.
+run_group() { # $1=image  $2=label  $3=batching  $4=freq_ms  $5=tests
+  local image=$1 label=$2 batching=$3 freq_ms=$4 tests=$5
+  local ip
+  ip=$(start_reader "$image" "$batching" "$freq_ms")
+  for t in $tests; do run_test "$ip" "$t" "$label"; done
+  docker rm -f reader >/dev/null 2>&1 || true
+}
+
+# Recreate a clean MySQL and set NET to its docker network.
+fresh_infra() {
+  ( cd "$INFRA_DIR" && docker compose down -v >/dev/null 2>&1 || true )
+  ( cd "$INFRA_DIR" && MYSQL_VERSIONS="$MYSQL_VERSION" docker compose up -d mysql )
+  # wait up to ~5 min (60 x 5s) for the infra healthcheck to report healthy
+  for _ in $(seq 1 60); do
+    [ "$(docker inspect -f '{{.State.Health.Status}}' "$INFRA_CONTAINER" 2>/dev/null)" = healthy ] && break
+    sleep 5
+  done
+  # let MySQL settle after it reports healthy
+  sleep 5
+  NET=$(docker inspect "$INFRA_CONTAINER" \
+        --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}}{{end}}')
+}
+
+for distro in $DISTROS; do
+  echo "================ DISTRO=$distro ================"
+  img="${IMAGE_PREFIX}:${distro}"
+  fresh_infra
+
+  # Warm the caching_sha2 cache for root@'%' with a TLS client first: the
+  # reader connects with SSL disabled, so it can only pass the warm fast-auth
+  # path, never the cold handshake.
+  docker run --rm --network "$NET" -e MYSQL_PORT="$MYSQL_PORT" \
+    --entrypoint bash "$INFRA_IMG" \
+    -c 'cli=$(ls /root/opt/mysql/8.4*/bin/mysql); "$cli" -h mysql -P "$MYSQL_PORT" -uroot -proot -e "SELECT 1"'
+
+  # Batching group first (cleanest GTID state), then the normal group.
+  run_group "$img" "$distro-batching" 1 300 "$BATCH_TESTS"
+  run_group "$img" "$distro-normal"   0 0   "$NORMAL_TESTS"
+done
+
+( cd "$INFRA_DIR" && docker compose down -v >/dev/null 2>&1 || true )
+echo "overall rc=$rc"
+exit "$rc"

--- a/test/tap/tap_utils.h
+++ b/test/tap/tap_utils.h
@@ -1,6 +1,8 @@
 #ifndef BINLOG_READER_TEST_TAP_UTILS_H
 #define BINLOG_READER_TEST_TAP_UTILS_H
 
+#include <unistd.h>
+
 #include <string>
 
 #include "tap.h"
@@ -52,6 +54,9 @@ inline std::string setup_reader(const CommandLine &cli, BinlogReaderProcess &rea
 		diag("connect mode: skipping spawn (reader expected at %s:%d)",
 		   cli.reader_host.c_str(), cli.reader_port);
 		reader_host = cli.reader_host;
+		// Give the external reader time to catch up the DB setup before
+		// the client connects.
+		sleep(3);
 	}
 
 	return reader_host;

--- a/test/tap/tests/test_basic_updates-t.cpp
+++ b/test/tap/tests/test_basic_updates-t.cpp
@@ -33,7 +33,8 @@ int main() {
 		BAIL_OUT("cannot connect to MySQL: %s", db.last_error().c_str());
 	}
 
-	db.reset_gtid_set();
+	if (!cli.reader_bin.empty())  // reset gtid only in spawn mode
+		db.reset_gtid_set();
 
 	db.exec("CREATE DATABASE IF NOT EXISTS binlog_reader_test");
 	db.exec("CREATE TABLE IF NOT EXISTS binlog_reader_test.updates_t "

--- a/test/tap/tests/test_batched_updates-t.cpp
+++ b/test/tap/tests/test_batched_updates-t.cpp
@@ -45,7 +45,8 @@ int main() {
 		BAIL_OUT("cannot connect to MySQL: %s", db.last_error().c_str());
 	}
 
-	db.reset_gtid_set();
+	if (!cli.reader_bin.empty())  // reset gtid only in spawn mode
+		db.reset_gtid_set();
 
 	db.exec("CREATE DATABASE IF NOT EXISTS binlog_reader_test");
 	db.exec("CREATE TABLE IF NOT EXISTS binlog_reader_test.batching_t "

--- a/test/tap/tests/test_connect_disconnect-t.cpp
+++ b/test/tap/tests/test_connect_disconnect-t.cpp
@@ -38,7 +38,8 @@ int main() {
 		BAIL_OUT("cannot connect to MySQL: %s", db.last_error().c_str());
 	}
 
-	db.reset_gtid_set();
+	if (!cli.reader_bin.empty())  // reset gtid only in spawn mode
+		db.reset_gtid_set();
 
 	db.exec("CREATE DATABASE IF NOT EXISTS binlog_reader_test");
 	db.exec("CREATE TABLE IF NOT EXISTS binlog_reader_test.connect_disconnect_t "

--- a/test/tap/tests/test_consecutive_writes-t.cpp
+++ b/test/tap/tests/test_consecutive_writes-t.cpp
@@ -38,7 +38,8 @@ int main() {
 		BAIL_OUT("cannot connect to MySQL: %s", db.last_error().c_str());
 	}
 
-	db.reset_gtid_set();
+	if (!cli.reader_bin.empty())  // reset gtid only in spawn mode
+		db.reset_gtid_set();
 
 	db.exec("CREATE DATABASE IF NOT EXISTS binlog_reader_test");
 	db.exec("CREATE TABLE IF NOT EXISTS binlog_reader_test.throughput_t "

--- a/test/tap/tests/test_multi_client-t.cpp
+++ b/test/tap/tests/test_multi_client-t.cpp
@@ -35,7 +35,8 @@ int main() {
 		BAIL_OUT("cannot connect to MySQL: %s", db.last_error().c_str());
 	}
 
-	db.reset_gtid_set();
+	if (!cli.reader_bin.empty())  // reset gtid only in spawn mode
+		db.reset_gtid_set();
 
 	db.exec("CREATE DATABASE IF NOT EXISTS binlog_reader_test");
 	db.exec("CREATE TABLE IF NOT EXISTS binlog_reader_test.broadcast_t "


### PR DESCRIPTION
- Previously, the release workflow only built deb/rpm packages and attached them as release artifacts.
- This PR enhances that by introducing build and test jobs for the Docker container images.
- Each container image is tested with the existing TAP suite and pushed to GHCR only if the tests pass.
- Also adds a `BATCHING` env knob to the container image `CMD` for configurable batching.